### PR TITLE
chore: update currency library to avoid using overwriting free mem pointer

### DIFF
--- a/contracts/libraries/Currency.sol
+++ b/contracts/libraries/Currency.sol
@@ -32,27 +32,25 @@ library CurrencyLibrary {
             if (!success) revert NativeTransferFailed();
         } else {
             assembly {
-                // We'll write our calldata to this slot below, but restore it later.
-                let memPointer := mload(0x40)
+                // Get a pointer to some free memory.
+                let freeMemoryPointer := mload(0x40)
 
                 // Write the abi-encoded calldata into memory, beginning with the function selector.
-                mstore(0, 0xa9059cbb00000000000000000000000000000000000000000000000000000000)
-                mstore(4, to) // Append the "to" argument.
-                mstore(36, amount) // Append the "amount" argument.
+                mstore(freeMemoryPointer, 0xa9059cbb00000000000000000000000000000000000000000000000000000000)
+                mstore(add(freeMemoryPointer, 4), and(to, 0xffffffffffffffffffffffffffffffffffffffff)) // Append and mask the "to" argument.
+                mstore(add(freeMemoryPointer, 36), amount) // Append the "amount" argument. Masking not required as it's a full 32 byte type.
 
                 success :=
                     and(
                         // Set success to whether the call reverted, if not we check it either
                         // returned exactly 1 (can't just be non-zero data), or had no return data.
                         or(and(eq(mload(0), 1), gt(returndatasize(), 31)), iszero(returndatasize())),
-                        // We use 68 because that's the total length of our calldata (4 + 32 * 2)
-                        // Counterintuitively, this call() must be positioned after the or() in the
-                        // surrounding and() because and() evaluates its arguments from right to left.
-                        call(gas(), currency, 0, 0, 68, 0, 32)
+                        // We use 68 because the length of our calldata totals up like so: 4 + 32 * 2.
+                        // We use 0 and 32 to copy up to 32 bytes of return data into the scratch space.
+                        // Counterintuitively, this call must be positioned second to the or() call in the
+                        // surrounding and() call or else returndatasize() will be zero during the computation.
+                        call(gas(), currency, 0, freeMemoryPointer, 68, 0, 32)
                     )
-
-                mstore(0x60, 0) // Restore the zero slot to zero.
-                mstore(0x40, memPointer) // Restore the memPointer.
             }
 
             if (!success) revert ERC20TransferFailed();


### PR DESCRIPTION
- Update with latest solmate's [implementation](https://github.com/transmissions11/solmate/blob/c892309933b25c03d32b1b0d674df7ae292ba925/src/utils/SafeTransferLib.sol#L73-L92)