### PR TITLE
feat: make only provider can collect

### DIFF
--- a/contracts/BookManager.sol
+++ b/contracts/BookManager.sol
@@ -308,13 +308,13 @@ contract BookManager is IBookManager, Ownable2Step, ERC721Permit {
         emit Claim(id, claimedRaw);
     }
 
-    function collect(address provider, Currency currency) external {
-        uint256 amount = tokenOwed[provider][currency];
+    function collect(address recipient, Currency currency) external {
+        uint256 amount = tokenOwed[msg.sender][currency];
         if (amount > 0) {
-            tokenOwed[provider][currency] = 0;
+            tokenOwed[msg.sender][currency] = 0;
             reservesOf[currency] -= amount;
-            currency.transfer(provider, amount);
-            emit Collect(provider, currency, amount);
+            currency.transfer(recipient, amount);
+            emit Collect(msg.sender, recipient, currency, amount);
         }
     }
 

--- a/contracts/BookManager.sol
+++ b/contracts/BookManager.sol
@@ -308,14 +308,12 @@ contract BookManager is IBookManager, Ownable2Step, ERC721Permit {
         emit Claim(id, claimedRaw);
     }
 
-    function collect(address recipient, Currency currency) external {
-        uint256 amount = tokenOwed[msg.sender][currency];
-        if (amount > 0) {
-            tokenOwed[msg.sender][currency] = 0;
-            reservesOf[currency] -= amount;
-            currency.transfer(recipient, amount);
-            emit Collect(msg.sender, recipient, currency, amount);
-        }
+    function collect(address recipient, Currency currency) external returns (uint256 amount) {
+        amount = tokenOwed[msg.sender][currency];
+        tokenOwed[msg.sender][currency] = 0;
+        reservesOf[currency] -= amount;
+        currency.transfer(recipient, amount);
+        emit Collect(msg.sender, recipient, currency, amount);
     }
 
     function withdraw(Currency currency, address to, uint256 amount) external onlyByLocker {

--- a/contracts/interfaces/IBookManager.sol
+++ b/contracts/interfaces/IBookManager.sol
@@ -327,8 +327,9 @@ interface IBookManager is IERC721Metadata, IERC721Permit {
      * @notice Collects fees from a provider
      * @param recipient The recipient address
      * @param currency The currency
+     * @return The collected amount
      */
-    function collect(address recipient, Currency currency) external;
+    function collect(address recipient, Currency currency) external returns (uint256);
 
     /**
      * @notice Withdraws a currency

--- a/contracts/interfaces/IBookManager.sol
+++ b/contracts/interfaces/IBookManager.sol
@@ -94,10 +94,11 @@ interface IBookManager is IERC721Metadata, IERC721Permit {
     /**
      * @notice Event emitted when a provider collects fees
      * @param provider The provider address
+     * @param recipient The recipient address
      * @param currency The currency
      * @param amount The collected amount
      */
-    event Collect(address indexed provider, Currency indexed currency, uint256 amount);
+    event Collect(address indexed provider, address indexed recipient, Currency indexed currency, uint256 amount);
 
     /**
      * @notice Event emitted when new default provider is set
@@ -324,10 +325,10 @@ interface IBookManager is IERC721Metadata, IERC721Permit {
 
     /**
      * @notice Collects fees from a provider
-     * @param provider The provider address
+     * @param recipient The recipient address
      * @param currency The currency
      */
-    function collect(address provider, Currency currency) external;
+    function collect(address recipient, Currency currency) external;
 
     /**
      * @notice Withdraws a currency


### PR DESCRIPTION
This PR simplifies the collect feature by restricting it to providers only. Originally, allowing others to collect on behalf of a provider introduced complexities, especially for contracts needing to reconcile deducted balances.
To streamline operations and maintain security, I've now limited collection privileges solely to providers. Additionally, providers can specify a recipient address for the collected assets, offering flexibility in directing where assets should be sent post-collection.